### PR TITLE
add encoding marker to Pod

### DIFF
--- a/lib/Acme/CPANAuthors/Swedish.pm
+++ b/lib/Acme/CPANAuthors/Swedish.pm
@@ -22,6 +22,8 @@ __END__
 
 =pod
 
+=encoding UTF-8
+
 =head1 NAME
 
 Acme::CPANAuthors::Swedish - We are swedish CPAN authors


### PR DESCRIPTION
Hi,

There is a [rendering issue](http://search.cpan.org/~woldrich/Acme-CPANAuthors-Swedish-0.03/lib/Acme/CPANAuthors/Swedish.pm#NAME) with **ä** letter due to the lack of encoding declaration within Pod. This should fix it.

Cheers,
Sergey
